### PR TITLE
Ask for location permission #10

### DIFF
--- a/MineFieldAlarm/app/src/main/AndroidManifest.xml
+++ b/MineFieldAlarm/app/src/main/AndroidManifest.xml
@@ -2,7 +2,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.example.ladislav.minefieldalarm">
 
-    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.VIBRATE" />


### PR DESCRIPTION
Looks like the required permissions are already defined in the manifest. Took out "android.permission.ACCESS_COARSE_LOCATION " and kept the "android.permission.ACCESS_FINE_LOCATION" since you only need one of those and for this app the fine location permission seems appropriate.